### PR TITLE
Changes source for ecs service module

### DIFF
--- a/examples/ecs-service/main.tf
+++ b/examples/ecs-service/main.tf
@@ -71,8 +71,8 @@ module "ecs-cluster" {
   ]
 }
 
-module "ecs-taskdef-and-service" {
-  source = "../../modules/ecs-taskdef-and-service"
+module "ecs-service" {
+  source = "../../modules/ecs-service"
 
   # Task Definition Parameters
   ecs_taskdef_family                = "${local.project_name}-taskdef"


### PR DESCRIPTION
Story [15159](https://app.shortcut.com/clarkcan/story/15159/ecs-service-task-def-example-bug) fixes a bug for the example for utilizing the ecs-service. I renamed ecs-service-and-taskdef to just ecs-service, but that left a bug to rename the ecs-service module in the examples. 