### PR TITLE
chore: [sc-27243] Refactor spacelift-stack module label

### DIFF
--- a/modules/spacelift-stack/README.md
+++ b/modules/spacelift-stack/README.md
@@ -112,6 +112,10 @@ module "example" {
 	 enable_iam_integration  = bool
 
 
+	 # Whether to enable an initial tracked run when Spacelift stack is first created.
+	 enable_init_run  = bool
+
+
 	 # Whether to protect the stack from deletion. This value should only be changed if you understand the implications of doing so.
 	 enable_protect_from_deletion  = bool
 
@@ -216,6 +220,14 @@ Description: Whether to enable an IAM role to be created for the stack.
 Type: `bool`
 
 Default: `true`
+
+### <a name="input_enable_init_run"></a> [enable\_init\_run](#input\_enable\_init\_run)
+
+Description: Whether to enable an initial tracked run when Spacelift stack is first created.
+
+Type: `bool`
+
+Default: `false`
 
 ### <a name="input_enable_protect_from_deletion"></a> [enable\_protect\_from\_deletion](#input\_enable\_protect\_from\_deletion)
 

--- a/modules/spacelift-stack/main.tf
+++ b/modules/spacelift-stack/main.tf
@@ -199,7 +199,7 @@ resource "spacelift_stack_dependency_reference" "this" {
 # ---------------------------------------------------
 
 resource "spacelift_run" "this" {
-  count = var.enable_admin_stack ? 1 : 0
+  count = var.enable_admin_stack || var.enable_init_run ? 1 : 0
 
   stack_id = spacelift_stack.this.id
 

--- a/modules/spacelift-stack/variables.tf
+++ b/modules/spacelift-stack/variables.tf
@@ -63,6 +63,12 @@ variable "enable_iam_integration" {
   default     = true
 }
 
+variable "enable_init_run" {
+  description = "Whether to enable an initial tracked run when Spacelift stack is first created."
+  type        = bool
+  default     = false
+}
+
 variable "enable_protect_from_deletion" {
   description = "Whether to protect the stack from deletion. This value should only be changed if you understand the implications of doing so."
   type        = bool


### PR DESCRIPTION
Story details: https://app.shortcut.com/clarkcan/story/27243

The initial reason for this PR was to prevent re-create (-/+) on module new name. However the following documentation clarifies the refactor process. https://developer.hashicorp.com/terraform/language/modules/develop/refactoring#renaming-a-module-call (this is linked in the story for future reference)

Instead the init run is added to allow for a stack to be initially run on creation. This is useful for staging environments.